### PR TITLE
Azure FHIR artifact

### DIFF
--- a/massdriver.yaml
+++ b/massdriver.yaml
@@ -82,8 +82,11 @@ connections:
       $ref: massdriver/azure-service-principal
 
 artifacts:
-  required: []
-  properties: {}
+  required:
+    - azure_fhir_service
+  properties:
+    azure_fhir_service:
+      $ref: massdriver/azure-fhir-service
 
 ui:
   ui:order:

--- a/src/_artifacts.tf
+++ b/src/_artifacts.tf
@@ -1,0 +1,18 @@
+resource "massdriver_artifact" "fhir" {
+  field                = "azure_fhir_service"
+  provider_resource_id = azurerm_healthcare_fhir_service.main.id
+  name                 = "Azure FHIR Service ${var.md_metadata.name_prefix} (${azurerm_healthcare_fhir_service.main.id})"
+  artifact = jsonencode(
+    {
+      data = {
+        infrastructure = {
+          ari = azurerm_healthcare_fhir_service.main.id
+        }
+        authentication = {
+          authority = azurerm_healthcare_fhir_service.main.authentication[0].authority
+          audience  = azurerm_healthcare_fhir_service.main.authentication[0].audience
+        }
+      }
+    }
+  )
+}

--- a/src/main.tf
+++ b/src/main.tf
@@ -41,4 +41,11 @@ resource "azurerm_healthcare_fhir_service" "main" {
       image_name   = oci_artifact.value.image_name
     }
   }
+
+  cors {
+    allowed_origins    = ["*"]
+    allowed_headers    = ["*"]
+    allowed_methods    = ["DELETE", "GET", "POST", "OPTIONS", "PUT"]
+    max_age_in_seconds = 600
+  }
 }


### PR DESCRIPTION
Artifact file for Azure FHIR service.

Removed the `specs` block because it conflicts with the Azure regions available for FHIR service.